### PR TITLE
add num.rixfr

### DIFF
--- a/source/manpages/nsd-control.rst
+++ b/source/manpages/nsd-control.rst
@@ -329,6 +329,9 @@ num.txerr
 num.raxfr
         number of AXFR requests from clients (that got served with reply).
 
+num.rixfr
+        number of IXFR requests from clients (that got served with reply).
+
 num.truncated
         number of answers with TC flag set.
 


### PR DESCRIPTION
`nsd-control stats` also returns "num.rixfr" in newer versions, according to the changelog this was introduced in 4.5.0

This PR updates the nsd-manual accordingly.