### PR TITLE
Make BIND/NSD config examples separate

### DIFF
--- a/source/manpages/nsd.conf.rst
+++ b/source/manpages/nsd.conf.rst
@@ -950,7 +950,7 @@ Here is an example of a master zone in BIND9 syntax.
                 file "example.nl";
         };
 
-        In NSD syntax this becomes:
+In NSD syntax this becomes:
 
         zone:
                 name: "example.nl"


### PR DESCRIPTION
So that the presentation matches that of earlier examples in the page.